### PR TITLE
Handle Non-Page Builder CMS Block Creation

### DIFF
--- a/Plugin/AddCmsBlockIdentifierToMarkup.php
+++ b/Plugin/AddCmsBlockIdentifierToMarkup.php
@@ -40,14 +40,23 @@ class AddCmsBlockIdentifierToMarkup
             && ($identifier = $block->getIdentifier())
             && ($content = $block->getContent())
         ) {
-            $block->setContent(
-                substr_replace(
-                    $content,
-                    ' data-' . $this->moduleConfig->getBlockIdentifierDataAttributeName() . '="' . $identifier . '"',
-                    strpos($content, '<div') + 4,
-                    0
-                )
-            );
+            $firstWord = strtok($content, ' ');
+
+            // if tags are removed from the first "word" and the values are not equal then we have HTML to edit
+            if (strip_tags($firstWord) !== $firstWord) {
+                $tag = explode('>', explode('<', $content)[1])[0]; // parsing HTML with PHP is gross
+
+                $block->setContent(
+                    substr_replace(
+                        $content,
+                        ' data-' . $this->moduleConfig->getBlockIdentifierDataAttributeName() . '="' . $identifier . '"',
+                        strpos($content, $tag) + strlen($tag),
+                        0
+                    )
+                );
+            } else {
+                $block->setContent('<!-- CMS identifier = ' . $identifier . ' -->' . "\n" . $content);
+            }
         }
 
         return [$block];

--- a/Plugin/AddCmsBlockIdentifierToMarkup.php
+++ b/Plugin/AddCmsBlockIdentifierToMarkup.php
@@ -54,7 +54,7 @@ class AddCmsBlockIdentifierToMarkup
                         0
                     )
                 );
-            } else {
+            } else if ($this->moduleConfig->useHtmlComments()) {
                 $block->setContent('<!-- CMS identifier = ' . $identifier . ' -->' . "\n" . $content);
             }
         }

--- a/Scope/Config.php
+++ b/Scope/Config.php
@@ -14,6 +14,7 @@ class Config
 {
     const XML_PATH_CMS_IDENTIFIER_MARKUP_ENABLED = 'cms/pagebuilder/block_identifier_markup_enabled';
     const XML_PATH_CMS_IDENTIFIER_DATA_ATTR_NAME = 'cms/pagebuilder/block_identifier_attribute_name';
+    const XML_PATH_CMS_IDENTIFIER_HTML_COMMENT = 'cms/pagebuilder/block_identifier_comment';
 
     /** @var ScopeConfigInterface */
     private ScopeConfigInterface $scopeConfig;
@@ -48,6 +49,19 @@ class Config
     {
         return $this->scopeConfig->getValue(
             self::XML_PATH_CMS_IDENTIFIER_DATA_ATTR_NAME,
+            ScopeInterface::SCOPE_STORE,
+            $scopeCode
+        );
+    }
+
+    /**
+     * @param int|string|null $scopeCode
+     * @return bool
+     */
+    public function useHtmlComments($scopeCode = null): bool
+    {
+        return $this->scopeConfig->isSetFlag(
+            self::XML_PATH_CMS_IDENTIFIER_HTML_COMMENT,
             ScopeInterface::SCOPE_STORE,
             $scopeCode
         );

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -41,6 +41,23 @@
                         <field id="cms/pagebuilder/block_identifier_markup_enabled">1</field>
                     </depends>
                 </field>
+                <field id="block_identifier_comment"
+                       translate="label comment"
+                       type="select"
+                       sortOrder="3020"
+                       showInDefault="1"
+                       showInWebsite="1"
+                       showInStore="1"
+                       canRestore="1">
+                    <label>Use HTML Comments for non-HTML Content</label>
+                    <comment>
+                        A HTML comment will be used when the block content does not contain a wrapping HTML tag to edit.
+                    </comment>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <depends>
+                        <field id="cms/pagebuilder/block_identifier_markup_enabled">1</field>
+                    </depends>
+                </field>
             </group>
         </section>
     </system>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -12,6 +12,7 @@
             <pagebuilder>
                 <block_identifier_markup_enabled>1</block_identifier_markup_enabled>
                 <block_identifier_attribute_name>block-identifier</block_identifier_attribute_name>
+                <block_identifier_comment>1</block_identifier_comment>
             </pagebuilder>
         </cms>
     </default>


### PR DESCRIPTION
Resolves #1 

# Description
- Adds admin configuration to allow HTML comments to be added to CMS blocks that do not have a wrapping HTML element
- Update the logic that adds the identifier to the CMS block to handle blocks created by means other than Page Builder
